### PR TITLE
Fixing asm.js node module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/asm.js
+++ b/lib/asm.js
@@ -1,0 +1,5 @@
+module.exports = {
+    validate: require('./validate'),
+    ValidationError: require('./fail').ValidationError,
+    types: require('./types')
+};

--- a/lib/tables.js
+++ b/lib/tables.js
@@ -1,0 +1,101 @@
+var dict = require('dict');
+var ty = require('./types');
+
+exports.ROOT_NAMES = ['stdlib', 'foreign', 'heap'];
+
+exports.HEAP_VIEW_TYPES = dict({
+    'Int8Array':    ty.View(1, ty.Intish),
+    'Uint8Array':   ty.View(1, ty.Intish),
+    'Int16Array':   ty.View(2, ty.Intish),
+    'Uint16Array':  ty.View(2, ty.Intish),
+    'Int32Array':   ty.View(4, ty.Intish),
+    'Uint32Array':  ty.View(4, ty.Intish),
+    'Float32Array': ty.View(4, ty.Doublish),
+    'Float64Array': ty.View(8, ty.Doublish)
+});
+
+var DoublishToDouble = ty.Arrow([ty.Doublish], ty.Double);
+
+exports.STDLIB_TYPES = dict({
+    'Infinity': ty.Double,
+    'NaN':      ty.Double
+});
+
+exports.STDLIB_MATH_TYPES = dict({
+    'acos':    DoublishToDouble,
+    'asin':    DoublishToDouble,
+    'atan':    DoublishToDouble,
+    'cos':     DoublishToDouble,
+    'sin':     DoublishToDouble,
+    'tan':     DoublishToDouble,
+    'ceil':    DoublishToDouble,
+    'floor':   DoublishToDouble,
+    'exp':     DoublishToDouble,
+    'log':     DoublishToDouble,
+    'sqrt':    DoublishToDouble,
+    'abs':     ty.Overloaded([
+                   ty.Arrow([ty.Signed], ty.Unsigned),
+                   DoublishToDouble
+               ]),
+    'atan2':   ty.Arrow([ty.Doublish, ty.Doublish], ty.Double),
+    'pow':     ty.Arrow([ty.Doublish, ty.Doublish], ty.Double),
+    'imul':    ty.Arrow([ty.Int, ty.Int], ty.Signed),
+    'E':       ty.Double,
+    'LN10':    ty.Double,
+    'LN2':     ty.Double,
+    'LOG2E':   ty.Double,
+    'LOG10E':  ty.Double,
+    'PI':      ty.Double,
+    'SQRT1_2': ty.Double,
+    'SQRT2':   ty.Double
+});
+
+var SignedBitwise = ty.Arrow([ty.Intish, ty.Intish], ty.Signed);
+
+var RelOp = ty.Overloaded([
+    ty.Arrow([ty.Signed, ty.Signed], ty.Int),
+    ty.Arrow([ty.Unsigned, ty.Unsigned], ty.Int),
+    ty.Arrow([ty.Double, ty.Double], ty.Int)
+]);
+
+exports.BINOPS = dict({
+    '+':   ty.Arrow([ty.Double, ty.Double], ty.Double),
+    '-':   ty.Arrow([ty.Doublish, ty.Doublish], ty.Double),
+    '*':   ty.Arrow([ty.Doublish, ty.Doublish], ty.Double),
+    '/':   ty.Overloaded([
+        ty.Arrow([ty.Signed, ty.Signed], ty.Intish),
+        ty.Arrow([ty.Unsigned, ty.Unsigned], ty.Intish),
+        ty.Arrow([ty.Doublish, ty.Doublish], ty.Double)
+    ]),
+    '%':   ty.Overloaded([
+        ty.Arrow([ty.Signed, ty.Signed], ty.Intish),
+        ty.Arrow([ty.Unsigned, ty.Unsigned], ty.Intish),
+        ty.Arrow([ty.Doublish, ty.Doublish], ty.Double)
+    ]),
+    '|':   SignedBitwise,
+    '&':   SignedBitwise,
+    '^':   SignedBitwise,
+    '<<':  SignedBitwise,
+    '>>':  SignedBitwise,
+    '>>>': ty.Arrow([ty.Intish, ty.Intish], ty.Unsigned),
+    '<':   RelOp,
+    '<=':  RelOp,
+    '>':   RelOp,
+    '>=':  RelOp,
+    '==':  RelOp,
+    '!=':  RelOp
+});
+
+exports.UNOPS = dict({
+    '+': ty.Overloaded([
+        ty.Arrow([ty.Signed], ty.Double),
+        ty.Arrow([ty.Unsigned], ty.Double),
+        ty.Arrow([ty.Doublish], ty.Double)
+    ]),
+    '-': ty.Overloaded([
+        ty.Arrow([ty.Int], ty.Intish),
+        ty.Arrow([ty.Doublish], ty.Double)
+    ]),
+    '~': ty.Arrow([ty.Intish], ty.Signed),
+    '!': ty.Arrow([ty.Int], ty.Int)
+});

--- a/tests/asmAssert.js
+++ b/tests/asmAssert.js
@@ -1,5 +1,6 @@
-var validate = require('../lib/validate');
-var fail = require('../lib/fail');
+var asm = require('../lib/asm');
+var validate = asm.validate;
+var ValidationError = asm.ValidationError;
 
 function explode(test) {
     var __EMPTY__ = [];
@@ -13,7 +14,7 @@ function explode(test) {
                        .replace("__ALL__", __ALL__.join(SEP));
 }
 
-function asm(msg, f, expect) {
+function asmAssert(msg, f, expect) {
     f = explode(f);
     var hasOwn = {}.hasOwnProperty;
 
@@ -61,7 +62,7 @@ function asm(msg, f, expect) {
         return function(test) {
             test.throws(function() { validate(f); },
                         function(e) {
-                            return e instanceof fail.ValidationError;
+                            return e instanceof ValidationError;
                         },
                         msg + ": should fail to validate");
             test.done();
@@ -69,10 +70,10 @@ function asm(msg, f, expect) {
     }
 }
 
-asm.one = function(msg, f, expect) {
-    return asm(msg,
+asmAssert.one = function(msg, f, expect) {
+    return asmAssert(msg,
                "function one(stdlib, foreign, heap) {\n    'use asm';\n    __ALL__\n    " + f + "\n    return {};\n}",
                expect);
 };
 
-module.exports = asm;
+module.exports = asmAssert;

--- a/tests/index.js
+++ b/tests/index.js
@@ -1,7 +1,7 @@
 var ty = require('../lib/types');
-var asm = require('./asm');
+var asmAssert = require('./asmAssert');
 
-exports.testModuloIntish1 = asm.one(
+exports.testModuloIntish1 = asmAssert.one(
     "% doesn't return int",
     function f() {
         var x = 0, y = 0;
@@ -9,7 +9,7 @@ exports.testModuloIntish1 = asm.one(
     },
     { pass: false });
 
-exports.testModuleIntish2 = asm.one(
+exports.testModuleIntish2 = asmAssert.one(
     "% returns intish",
     function f() {
         var x = 0, y = 0;
@@ -17,7 +17,7 @@ exports.testModuleIntish2 = asm.one(
     },
     { pass: true });
 
-exports.testIntCoercionRequiresDouble1 = asm.one(
+exports.testIntCoercionRequiresDouble1 = asmAssert.one(
     "~~ requires double",
     function f() {
         var x = 0.0, y = 0;
@@ -25,7 +25,7 @@ exports.testIntCoercionRequiresDouble1 = asm.one(
     },
     { pass: false });
 
-exports.testIntCoercionRequiresDouble2 = asm.one(
+exports.testIntCoercionRequiresDouble2 = asmAssert.one(
     "~~ requires double",
     function f() {
         var x = 0.0, y = 0;
@@ -33,7 +33,7 @@ exports.testIntCoercionRequiresDouble2 = asm.one(
     },
     { pass: true });
 
-exports.testNot = asm.one(
+exports.testNot = asmAssert.one(
     "! operator",
     function f() {
         var x = 0;
@@ -41,7 +41,7 @@ exports.testNot = asm.one(
     },
     { pass: true });
 
-exports.testParamTypes = asm.one(
+exports.testParamTypes = asmAssert.one(
     "different parameter types",
     function f(x, y) {
         x = x|0;
@@ -53,7 +53,7 @@ exports.testParamTypes = asm.one(
         }
     });
 
-exports.testAdd = asm.one(
+exports.testAdd = asmAssert.one(
     "addition",
     function add1(x) {
         x = x|0;
@@ -65,7 +65,7 @@ exports.testAdd = asm.one(
         }
     });
 
-exports.testImul = asm.one(
+exports.testImul = asmAssert.one(
     "Math.imul",
     function double(x) {
         x = x|0;
@@ -75,7 +75,7 @@ exports.testImul = asm.one(
         double: ty.Arrow([ty.Int], ty.Signed)
     });
 
-exports.testLoad = asm.one(
+exports.testLoad = asmAssert.one(
     "heap load",
     function get(i) {
         i = i|0;
@@ -87,7 +87,7 @@ exports.testLoad = asm.one(
         }
     });
 
-exports.testStore = asm.one(
+exports.testStore = asmAssert.one(
     "heap store",
     function set(i, x) {
         i = i|0;
@@ -100,7 +100,7 @@ exports.testStore = asm.one(
         }
     });
 
-exports.testCall1 = asm(
+exports.testCall1 = asmAssert(
     "function call",
     function call(stdlib, foreign, heap) {
         "use asm";
@@ -117,7 +117,7 @@ exports.testCall1 = asm(
         return {};
     }, { pass: true });
 
-exports.testCall2 = asm(
+exports.testCall2 = asmAssert(
     "function call",
     function call(stdlib, foreign, heap) {
         "use asm";
@@ -134,7 +134,7 @@ exports.testCall2 = asm(
         return {};
     }, { pass: false });
 
-exports.testVoid1 = asm(
+exports.testVoid1 = asmAssert(
     "void function call in expression statement",
     function void_(stdlib) {
         "use asm";
@@ -146,7 +146,7 @@ exports.testVoid1 = asm(
         return {}
     }, { pass: true });
 
-exports.testVoid2 = asm(
+exports.testVoid2 = asmAssert(
     "void function call in comma expression",
     function void_(stdlib) {
         "use asm";
@@ -159,7 +159,7 @@ exports.testVoid2 = asm(
         return {};
     }, { pass: true });
 
-exports.testEval1 = asm(
+exports.testEval1 = asmAssert(
     "module named eval",
     function eval() {
         "use asm";
@@ -168,7 +168,7 @@ exports.testEval1 = asm(
         return empty;
     }, { pass: false });
 
-exports.testEval2 = asm(
+exports.testEval2 = asmAssert(
     "function named eval",
     function() {
         "use asm";
@@ -177,7 +177,7 @@ exports.testEval2 = asm(
         return eval;
     }, { pass: false });
 
-exports.testEval3 = asm(
+exports.testEval3 = asmAssert(
     "local named eval",
     function() {
         "use asm";


### PR DESCRIPTION
Hi Dave,

_If you're already working on this or there's something else in the pipeline, or if this pull request is generally off the mark, please disregard._

---

Currently `main` in `package.json` points to `lib/asm.js` which doesn't exist. I've created a `lib/asm.js` -- it just includes the basic stuff an asmjs-node-module consumer might want to access (at the moment: validate, types, ValidationError).

I also noticed the nodeunit tests were not succeeding so I've restored tables.js (which was missing [?]). Tests succeed now:

``` bash
$ nodeunit tests/index.js

index
✔ testModuloIntish1
✔ testModuleIntish2
✔ testIntCoercionRequiresDouble1
✔ testIntCoercionRequiresDouble2
✔ testNot
✔ testParamTypes
✔ testAdd
✔ testImul
✔ testLoad
✔ testStore
✔ testCall1
✔ testCall2
✔ testVoid1
✔ testVoid2
✔ testEval1
✔ testEval2
✔ testEval3
```

Also changed `tests/asm.js` to `asmAssert.js` for clarity and to avoid ambiguity with the new `lib/asm.js`.

Please let me know if any further changes are required.
