### PR TITLE
Add validateAst function for validating an AST

### DIFF
--- a/lib/asm.js
+++ b/lib/asm.js
@@ -1,5 +1,6 @@
 module.exports = {
-    validate: require('./validate'),
+    validate: require('./validate').validate,
+    validateAst: require('./validate').validateAst,
     ValidationError: require('./fail').ValidationError,
     types: require('./types')
 };

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -140,8 +140,13 @@ Vp.match = function(node, desc, body) {
 Vp.validate = function validate(src) {
     this._src = src;
     var module = esprima.parse("(" + src + ")", { raw: true, loc: true }).body[0].expression;
+    return this.validateAst(module);
+};
+
+// (FunctionExpression | FunctionDeclaration) -> Report
+Vp.validateAst = function validateAst(module) {
     var vars = this.match(module, "asm.js module declaration").when({
-        type: 'FunctionExpression',
+        type: match.some('FunctionExpression', 'FunctionDeclaration'),
         id: match.var('id', { type: 'Identifier' }),
         params: match.var('params', { length: match.range(0, 4) }),
         body: { loc: match.var('loc'), body: match.var('body') }
@@ -1041,6 +1046,11 @@ Vp.call = function call(e, t) {
 // -----------------------------------------------------------------------------
 
 // (string) -> Report
-module.exports = function validate(src) {
+module.exports.validate = function validate(src) {
     return (new Validator).validate(src);
+};
+
+// (FunctionExpression | FunctionDeclaration) -> Report
+module.exports.validateAst = function validateAst(module) {
+    return (new Validator).validateAst(module);
 };


### PR DESCRIPTION
`validate()` expects a string, but other validation and compilation tools are likely to already have an ESTree-style AST. This exposes an API for validation with an Esprima-compatible AST.

For an example use-case, see [eslint-plugin-asmjs](https://github.com/bgw/eslint-plugin-asmjs).
