### PR TITLE
Don't fail validation on case statements.

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -763,8 +763,16 @@ Vp.switchStatement = function switchStatement(disc, cases) {
 
 // (SwitchCase, Type) -> void
 Vp.case = function case_(c, s) {
-    if (c.test)
-        this.checkSubtype(this.literal(c.test), s, "case clause expression", c.test.loc);
+    if (c.test) {
+      this.match(c.test, "case clause expression", function(when) {
+        when({
+            type: 'Literal',
+            value: match.all(match.number,
+                             match.range(-0x80000000, 0x80000000)),
+            raw: dotless
+          });
+      });
+    }
     this.statements(c.consequent);
 };
 


### PR DESCRIPTION
I think some vestigial code may have been left over: this.literal is not a function
